### PR TITLE
feat/add screens and header component

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import { ThemeProvider } from 'styled-components/native';
-import { useFonts, Inter_400Regular, Inter_500Medium, Inter_700Bold } from '@expo-google-fonts/inter';
+import { useFonts, Inter_400Regular, Inter_500Medium, Inter_600SemiBold, Inter_700Bold } from '@expo-google-fonts/inter';
 
 import { Loading } from '@components/Loading';
 
@@ -8,7 +8,7 @@ import theme from '@theme/index';
 import { Routes } from '@routes/index';
 
 export default function App() {
-  const [ fontsLoaded ] = useFonts({ Inter_400Regular, Inter_500Medium, Inter_700Bold });
+  const [ fontsLoaded ] = useFonts({ Inter_400Regular, Inter_500Medium, Inter_600SemiBold, Inter_700Bold });
 
   return (
     <SafeAreaProvider>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,0 +1,16 @@
+import { HeaderContainer, ScreenName, NotificationButton, NotificationIcon } from "./styles";
+
+type Props = {
+  title: string;
+}
+
+export function Header({ title }: Props) {
+  return (
+    <HeaderContainer>
+      <ScreenName>{title}</ScreenName>
+      <NotificationButton>
+        <NotificationIcon/>
+      </NotificationButton>
+    </HeaderContainer>
+  )
+}

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -1,0 +1,38 @@
+import theme from "@theme/index";
+import { BellIcon } from "phosphor-react-native";
+import styled, { css } from "styled-components/native";
+
+export const HeaderContainer = styled.View`
+ ${({ theme }) => css`
+  background-color: ${theme.COLORS.BACKGROUND};
+  border-bottom-color: ${theme.COLORS.BORDER};
+ `};
+  width: 100%;
+  height: 70px;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom-width: 0.8px;
+`;
+
+export const ScreenName = styled.Text`
+  ${({ theme }) => css`
+    font-family: ${theme.FONT_FAMILY.SEMIBOLD};
+    color: ${theme.COLORS.PRIMARY};
+  `}
+  font-size: 20px;
+  margin-left:20px;
+`;
+
+export const NotificationButton = styled.TouchableOpacity.attrs({
+  activeOpacity: 0.55
+})`
+  position: relative;
+  margin-right: 20px;
+`;
+
+export const NotificationIcon = styled(BellIcon).attrs({
+  size: 26,
+  color: theme.COLORS.PRIMARY,
+  weight: "bold"
+})``;

--- a/src/routes/bottomApp.routes.tsx
+++ b/src/routes/bottomApp.routes.tsx
@@ -6,6 +6,9 @@ import { HouseIcon, ChalkboardIcon, PlusSquareIcon, UserCircleIcon } from "phosp
 
 import { Home } from "@screens/Home";
 import { TouchableOpacity } from "react-native";
+import { ClassRoom } from "@screens/ClassRoom";
+import { RecordCleaning } from "@screens/RecordCleaning";
+import { Account } from "@screens/Account";
 
 type BottomAppProps = {
   home: undefined;
@@ -48,7 +51,7 @@ export function BottomApp() {
 
       <Screen 
         name="classRoom"
-        component={Home}
+        component={ClassRoom}
         options={{
           tabBarIcon: ({ color }) => <ChalkboardIcon weight="regular" size={24} color={theme.COLORS.BACKGROUND} />
         }}
@@ -56,7 +59,7 @@ export function BottomApp() {
 
       <Screen 
         name="recordCleaning"
-        component={Home}
+        component={RecordCleaning}
         options={{
           tabBarIcon: ({ color }) => <PlusSquareIcon weight="regular" size={24} color={theme.COLORS.BACKGROUND} />
         }}
@@ -64,7 +67,7 @@ export function BottomApp() {
 
       <Screen 
         name="account"
-        component={Home}
+        component={Account}
         options={{
           tabBarIcon: ({ color }) => <UserCircleIcon weight="regular" size={24} color={theme.COLORS.BACKGROUND} />
         }}

--- a/src/screens/Account/index.tsx
+++ b/src/screens/Account/index.tsx
@@ -1,9 +1,12 @@
-import { Container, Title } from "./styles";
+import { Header } from "@components/Header";
+import { Container, Main, Title } from "./styles";
 
 export function Account() {
   return(
     <Container>
-      <Title>Minha conta</Title>
+      <Main>
+        <Title>Minha conta</Title>
+      </Main>
     </Container>
   )
 }

--- a/src/screens/Account/index.tsx
+++ b/src/screens/Account/index.tsx
@@ -1,0 +1,9 @@
+import { Container, Title } from "./styles";
+
+export function Account() {
+  return(
+    <Container>
+      <Title>Minha conta</Title>
+    </Container>
+  )
+}

--- a/src/screens/Account/styles.ts
+++ b/src/screens/Account/styles.ts
@@ -1,0 +1,11 @@
+import styled from "styled-components/native";
+
+export const Container = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const Title = styled.Text`
+  font-size: 24px;
+`;

--- a/src/screens/Account/styles.ts
+++ b/src/screens/Account/styles.ts
@@ -1,9 +1,16 @@
+import { SafeAreaView } from "react-native-safe-area-context";
 import styled from "styled-components/native";
 
-export const Container = styled.View`
+export const Container = styled(SafeAreaView)`
   flex: 1;
   justify-content: center;
   align-items: center;
+`;
+
+export const Main = styled.View`
+  flex: 1;
+  background-color: ${({ theme }) => theme.COLORS.BACKGROUND};
+  padding: 15px 20px;
 `;
 
 export const Title = styled.Text`

--- a/src/screens/ClassRoom/index.tsx
+++ b/src/screens/ClassRoom/index.tsx
@@ -1,9 +1,12 @@
-import { Container, Title } from "./styles";
+import { Header } from "@components/Header";
+import { Container, Main } from "./styles";
 
 export function ClassRoom() {
   return(
     <Container>
-      <Title>Salas de aula</Title>
+      <Header title="Salas de aula"/>
+      <Main>
+      </Main>
     </Container>
   )
 }

--- a/src/screens/ClassRoom/index.tsx
+++ b/src/screens/ClassRoom/index.tsx
@@ -1,0 +1,9 @@
+import { Container, Title } from "./styles";
+
+export function ClassRoom() {
+  return(
+    <Container>
+      <Title>Salas de aula</Title>
+    </Container>
+  )
+}

--- a/src/screens/ClassRoom/styles.ts
+++ b/src/screens/ClassRoom/styles.ts
@@ -1,11 +1,14 @@
+import { SafeAreaView } from "react-native-safe-area-context";
 import styled from "styled-components/native";
 
-export const Container = styled.View`
+export const Container = styled(SafeAreaView)`
   flex: 1;
   justify-content: center;
   align-items: center;
 `;
 
-export const Title = styled.Text`
-  font-size: 24px;
+export const Main = styled.View`
+  flex: 1;
+  background-color: ${({ theme }) => theme.COLORS.BACKGROUND};
+  padding: 15px 20px;
 `;

--- a/src/screens/ClassRoom/styles.ts
+++ b/src/screens/ClassRoom/styles.ts
@@ -1,0 +1,11 @@
+import styled from "styled-components/native";
+
+export const Container = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const Title = styled.Text`
+  font-size: 24px;
+`;

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -1,9 +1,12 @@
-import { Container, Title } from "./styles";
+import { Header } from "@components/Header";
+import { Container, Main } from "./styles";
 
 export function Home() {
   return(
     <Container>
-      <Title>Home</Title>
+      <Header title="Gerenciamento de limpeza"/>
+      <Main>
+      </Main>
     </Container>
   )
 }

--- a/src/screens/Home/styles.ts
+++ b/src/screens/Home/styles.ts
@@ -1,11 +1,14 @@
+import { SafeAreaView } from "react-native-safe-area-context";
 import styled from "styled-components/native";
 
-export const Container = styled.View`
+export const Container = styled(SafeAreaView)`
   flex: 1;
   justify-content: center;
   align-items: center;
 `;
 
-export const Title = styled.Text`
-  font-size: 24px;
+export const Main = styled.View`
+  flex: 1;
+  background-color: ${({ theme }) => theme.COLORS.BACKGROUND};
+  padding: 15px 20px;
 `;

--- a/src/screens/RecordCleaning/index.tsx
+++ b/src/screens/RecordCleaning/index.tsx
@@ -1,9 +1,12 @@
-import { Container, Title } from "./styles";
+import { Header } from "@components/Header";
+import { Container, Main } from "./styles";
 
 export function RecordCleaning() {
   return(
     <Container>
-      <Title>Registrar limpeza</Title>
+      <Header title="Registrar limpeza"/>
+      <Main>
+      </Main>
     </Container>
   )
 }

--- a/src/screens/RecordCleaning/index.tsx
+++ b/src/screens/RecordCleaning/index.tsx
@@ -1,0 +1,9 @@
+import { Container, Title } from "./styles";
+
+export function RecordCleaning() {
+  return(
+    <Container>
+      <Title>Registrar limpeza</Title>
+    </Container>
+  )
+}

--- a/src/screens/RecordCleaning/styles.ts
+++ b/src/screens/RecordCleaning/styles.ts
@@ -1,11 +1,14 @@
+import { SafeAreaView } from "react-native-safe-area-context";
 import styled from "styled-components/native";
 
-export const Container = styled.View`
+export const Container = styled(SafeAreaView)`
   flex: 1;
   justify-content: center;
   align-items: center;
 `;
 
-export const Title = styled.Text`
-  font-size: 24px;
+export const Main = styled.View`
+  flex: 1;
+  background-color: ${({ theme }) => theme.COLORS.BACKGROUND};
+  padding: 15px 20px;
 `;

--- a/src/screens/RecordCleaning/styles.ts
+++ b/src/screens/RecordCleaning/styles.ts
@@ -1,0 +1,11 @@
+import styled from "styled-components/native";
+
+export const Container = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const Title = styled.Text`
+  font-size: 24px;
+`;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -20,6 +20,7 @@ export default {
   FONT_FAMILY: {
     REGULAR: "Inter_400Regular",
     MEDIUM: "Inter_500Medium",
+    SEMIBOLD: "Inter_600SemiBold",
     BOLD: "Inter_700Bold"
   }
 };


### PR DESCRIPTION
- Cria os arquivos iniciais para as telas principais da aplicação (`ClassRoom`, `RecordCleaning`, `Account`, etc.) dentro de `src/screens`
- Substitui os componentes `Home` genéricos no `BottomTabNavigator` pelas novas telas de placeholder correspondentes
- Cria um componente `<Header />` reutilizável em `src/components` para ser usado nas telas.
- Adiciona o `<Header />` a cada uma das novas telas, estabelecendo o layout visual base.